### PR TITLE
Feature/list-files

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ In order to use any of these APIs, you must first use the Google OAuth 2.0 libra
 
 ##### Supported Functionality
 
+* Getting all file ids and titles(in a map)
 * Creating a blank file
 * Uploading a file to drive
 * Updating a file's title

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ In order to use any of these APIs, you must first use the Google OAuth 2.0 libra
 ##### Supported Functionality
 
 * Getting all file ids and titles(in a map)
+* Getting a file by id
 * Creating a blank file
 * Uploading a file to drive
 * Updating a file's title

--- a/src/google_apps_clj/google_drive.clj
+++ b/src/google_apps_clj/google_drive.clj
@@ -35,6 +35,24 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; File Management ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(t/ann ^:no-check get-file-ids [cred/GoogleCtx -> (t/Map String String)])
+(defn get-file-ids
+  "Given a google-ctx configuration map, gets the file-id and title
+   for every file under the users Drive as a map in the structure
+   of {file-id file-title}"
+  [google-ctx]
+  (let [drive-service (build-drive-service google-ctx)
+        drive-files (doto (.files ^Drive drive-service)
+                      assert)
+        files-list (doto (.list drive-files)
+                     assert)
+        all-files (doto (.getItems (.execute files-list))
+                    assert)
+        extract-id (fn [file]
+                     (let [file-map (into {} file)]
+                       {(get file-map "id") (get file-map "title")}))]
+    (into {} (map extract-id all-files))))
+
 (t/ann upload-file [cred/GoogleCtx java.io.File String String String String -> File])
 (defn upload-file
   "Given a google-ctx configuration map, a file to upload, an ID of 

--- a/src/google_apps_clj/google_drive.clj
+++ b/src/google_apps_clj/google_drive.clj
@@ -53,6 +53,19 @@
                        {(get file-map "id") (get file-map "title")}))]
     (into {} (map extract-id all-files))))
 
+(t/ann get-file [cred/GoogleCtx String -> File])
+(defn get-file
+  "Given a google-ctx configuration map and the id of the desired
+  file as a string, returns that file as a drive File object"
+  [google-ctx file-id]
+  (let [drive-service (build-drive-service google-ctx)
+        drive-files (doto (.files ^Drive drive-service)
+                      assert)
+        get-file (doto (.get drive-files file-id)
+                   assert)]
+    (cast File (doto (.execute get-file)
+                 assert))))
+
 (t/ann upload-file [cred/GoogleCtx java.io.File String String String String -> File])
 (defn upload-file
   "Given a google-ctx configuration map, a file to upload, an ID of 


### PR DESCRIPTION
This adds in functionality to get a map of all file-ids and their corresponding titles for the Drive user who owns the authentication. With the ability to get ids, there is now a function to get a Drive File directly by id. This should close the open issue for `Missing functionality/docs`
