### PR TITLE
Express queries and results as data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+*-creds.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# google-apps-clj changes
+
+## 0.3.0
+
+* Began tracking changes
+* Major breaking changes to the drive ns, reworking it around
+  queries as data structures. This allows them to be modified
+  independently of their execution context (e.g. specifying fields)
+  and also faciliates the single and batched execution contexts.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,12 @@
 # google-apps-clj
 
-A Clojure library that wraps the Google Java API for different Google Applications. This library is fully supported by [core.typed](https://github.com/clojure/core.typed)
+A Clojure library that wraps the Google Java API for different Google
+Applications. This library is partially typed using core.typed.
 
 ## Obtaining
-If you are using Leiningen, you can add
-```
-[google-apps-clj "0.2.1"]
-```
-to your project.clj file and then run
-```
-lein deps
-```
-to download it from Clojars.
 
-If you are using Maven:
 ```
-<dependency>
-  <groupId>google-apps-clj</groupId>
-  <artifactId>google-apps-clj</artifactId>
-  <version>0.2.1</version>
-</dependency>
+[google-apps-clj "0.3.0"]
 ```
 
 ## Currently supported APIs
@@ -52,20 +39,12 @@ In order to use any of these APIs, you must first use the Google OAuth 2.0 libra
 
 ##### Supported Functionality
 
-* Getting all file ids and titles(in a map)
-* Getting a file by id
-* Creating a blank file
-* Uploading a file to drive
-* Updating a file's title
-* Updating a file's description
-* Getting a file's key-value pair properties
-* Editing a file's key-value pair properties
-* Deleting a file's key-value pair properties
-* Getting a file's permissions
-* Editing a file's permissions (by user)
-* Deleting a file's permissions (by user)
-* Downloading a file to drive
-* Deleting a file from drive(moves it to the trash)
+* Searching
+* Fetching
+* Uploading
+* Updating
+* Deleting
+* Authorizing
 
 ### Spreadsheet API
 
@@ -87,22 +66,29 @@ In order to use any of these APIs, you must first use the Google OAuth 2.0 libra
 * Listing all events within a certain date-time range (for user)
 * Listing all events on a given day (for user)
 * Listing upcoming events with a supplied name (for user)
-* Creating an event with a certain time range 
+* Creating an event with a certain time range
 * Creating an all day event
 
 ## What's Next?
 
+#### General
+
+* Allow service account authentication in addition to the current
+  user-account OAuth funkiness
+* Consider ditching the baroque Google java library in favor of
+  direct integration with the api using clj-http or the like
+
 #### Drive API
-* 
+* Consider making file maps the unit of work for the command fns
+* Or possibly an Identifiable protocol to allow file ids or maps
 
 #### Sheets API
-* 
+* Consider a cleaner abstraction instead of a grab bag of fns
 
 #### Calendar API
-* 
 
 ## License
 
-Copyright © 2015 
+Copyright © SparkFund 2015-2016
 
 Distributed under the Apache License, Version 2.0.

--- a/project.clj
+++ b/project.clj
@@ -8,4 +8,7 @@
                  [com.google.apis/google-api-services-calendar "v3-rev128-1.20.0"]
                  [com.google.apis/google-api-services-drive "v2-rev168-1.20.0"]
                  [com.google.gdata/core "1.47.1"]]
-  :repl-options {:init-ns google-apps-clj.repl})
+  :repl-options {:init-ns google-apps-clj.repl}
+  :test-selectors {:integration :integration
+                   :all (constantly true)
+                   :default (complement :integration)})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject google-apps-clj "0.2.2"
+(defproject google-apps-clj "0.3.0"
   :description "A Clojure library that wraps the Google Java API"
   :url "https://github.com/SparkFund/google-apps-clj"
   :license {:name "Apache License, Version 2.0"

--- a/project.clj
+++ b/project.clj
@@ -7,4 +7,5 @@
                  [org.clojure/core.typed "0.3.18"]
                  [com.google.apis/google-api-services-calendar "v3-rev128-1.20.0"]
                  [com.google.apis/google-api-services-drive "v2-rev168-1.20.0"]
-                 [com.google.gdata/core "1.47.1"]])
+                 [com.google.gdata/core "1.47.1"]]
+  :repl-options {:init-ns google-apps-clj.repl})

--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,8 @@
   :url "https://github.com/SparkFund/google-apps-clj"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/core.typed "0.3.0-alpha2"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [org.clojure/core.typed "0.3.18"]
                  [com.google.apis/google-api-services-calendar "v3-rev128-1.20.0"]
                  [com.google.apis/google-api-services-drive "v2-rev168-1.20.0"]
                  [com.google.gdata/core "1.47.1"]])

--- a/src/google_apps_clj/credentials.clj
+++ b/src/google_apps_clj/credentials.clj
@@ -85,7 +85,7 @@
       (.setRefreshToken (:refresh-token auth-map))
       (.setTokenType (:token-type auth-map)))))
 
-(t/ann build-credential [GoogleCtx -> HttpRequestInitializer])
+(t/ann ^:no-check build-credential [GoogleCtx -> HttpRequestInitializer])
 (defn build-credential
   "Given a google-ctx configuration map, builds a GoogleCredential Object from
    the token response and google secret created from those respective methods."

--- a/src/google_apps_clj/google_drive.clj
+++ b/src/google_apps_clj/google_drive.clj
@@ -66,6 +66,7 @@
   (let [drive-builder (->> google-ctx
                            cred/build-credential
                            (Drive$Builder. cred/http-transport cred/json-factory))]
+    (.setApplicationName drive-builder "google-apps-clj")
     (cast Drive (doto (.build drive-builder)
                   assert))))
 

--- a/src/google_apps_clj/google_drive.clj
+++ b/src/google_apps_clj/google_drive.clj
@@ -22,7 +22,7 @@
 
 (t/ann build-drive-service [cred/GoogleCtx -> Drive])
 (defn build-drive-service
-  "Given a google-ctx configuration map, builds a Drive service using 
+  "Given a google-ctx configuration map, builds a Drive service using
    credentials coming from the OAuth2.0 credential setup inside google-ctx"
   [google-ctx]
   (let [drive-builder (->> google-ctx
@@ -53,6 +53,20 @@
                        {(get file-map "id") (get file-map "title")}))]
     (into {} (map extract-id all-files))))
 
+(t/ann get-root-files [cred/GoogleCtx String -> (t/Seq File)])
+(defn get-root-files
+  "Given a google-ctx configuration map, gets a seq of files from the user's
+   root folder"
+  [google-ctx]
+  (let [files (some-> (build-drive-service google-ctx)
+                      .files
+                      .list
+                      (.setQ "'root' in parents and trashed=false")
+                      .execute
+                      .getItems)]
+    (assert files)
+    (tu/ignore-with-unchecked-cast files (t/Seq File))))
+
 (t/ann get-file [cred/GoogleCtx String -> File])
 (defn get-file
   "Given a google-ctx configuration map and the id of the desired
@@ -68,8 +82,8 @@
 
 (t/ann upload-file [cred/GoogleCtx java.io.File String String String String -> File])
 (defn upload-file
-  "Given a google-ctx configuration map, a file to upload, an ID of 
-   the parent folder you wish to insert the file in, the title of the 
+  "Given a google-ctx configuration map, a file to upload, an ID of
+   the parent folder you wish to insert the file in, the title of the
    Drive file, the description of the Drive file, and the MIME type of
    the file, builds a Drive Service and inserts this file into Google
    Drive with permissions of the folder it's inserted into. The owner
@@ -96,9 +110,9 @@
 (defn create-blank-file
   "Given a google-ctx configuration map, an ID of the parent folder you
    wish to insert the file in, the title of the Drive file, the description
-   of the Drive file, and the MIME type of the file(which will be converted 
-   into a google file type, builds a Drive Service and inserts a blank file 
-   into Google Drive with permissions of the folder it's inserted into. The 
+   of the Drive file, and the MIME type of the file(which will be converted
+   into a google file type, builds a Drive Service and inserts a blank file
+   into Google Drive with permissions of the folder it's inserted into. The
    owner is whomever owns the Credentials used to make the Drive Service"
   [google-ctx parent-folder-id file-title file-description media-type]
   (let [file (doto (java.io.File/createTempFile "temp" "temp")
@@ -107,8 +121,8 @@
 
 (t/ann download-file [cred/GoogleCtx String String -> String])
 (defn download-file
-  "Given a google-ctx configuration map, a file id to download, 
-   and a media type, download the drive file and then read it in 
+  "Given a google-ctx configuration map, a file id to download,
+   and a media type, download the drive file and then read it in
    and return the result of reading the file"
   [google-ctx file-id media-type]
   (let [drive-service (build-drive-service google-ctx)
@@ -209,7 +223,7 @@
 
 (t/ann update-property [cred/GoogleCtx String String String String -> Property])
 (defn update-property
-  "Given a google-ctx configuration map, a file id, a key, a value, and 
+  "Given a google-ctx configuration map, a file id, a key, a value, and
    a visibility(public or private) updates the property on this file to
    the new value if a property with the given key already exists, otherwise
    create a new one with this key value pair"

--- a/src/google_apps_clj/google_drive.clj
+++ b/src/google_apps_clj/google_drive.clj
@@ -465,7 +465,7 @@
                         {:model :permissions
                          :action :delete
                          :file-id file-id
-                         :permission-id (get permission "id")})
+                         :permission-id (:id permission)})
                       extant)]
     (execute! google-ctx deletes)
     nil))

--- a/src/google_apps_clj/google_drive.clj
+++ b/src/google_apps_clj/google_drive.clj
@@ -538,6 +538,17 @@
   "Returns a seq of files in the given folder"
   (execute-query! google-ctx (list-files folder-id)))
 
+(defn get-file
+  [file-id]
+  {:model :files
+   :action :get
+   :file-id file-id})
+
+(defn get-file!
+  [google-ctx file-id]
+  "Returns the metadata for the given file"
+  (execute-query! google-ctx (get-file file-id)))
+
 ;;; These vars probably belong elsewhere, e.g. a google-drive.repl ns
 
 (defn all-files

--- a/src/google_apps_clj/google_drive.clj
+++ b/src/google_apps_clj/google_drive.clj
@@ -457,7 +457,7 @@
    other operation."
   [google-ctx deauthorization]
   (let [{:keys [file-id principal]} deauthorization
-        extant (find-extant-permissions google-ctx file-id principal)
+        extant (find-extant-permissions! google-ctx file-id principal)
         deletes (mapv (fn [permission]
                         {:model :permissions
                          :action :delete
@@ -466,6 +466,9 @@
                       extant)]
     (execute! google-ctx deletes)
     nil))
+
+(def folder-mime-type
+  "application/vnd.google-apps.folder")
 
 (defn create-folder
   [parent-id title]
@@ -549,6 +552,10 @@
   "Returns the metadata for the given file"
   (execute-query! google-ctx (get-file file-id)))
 
+(defn with-fields
+  [request fields]
+  (update-in request [:fields] (fnil into #{}) fields))
+
 ;;; These vars probably belong elsewhere, e.g. a google-drive.repl ns
 
 (defn all-files
@@ -566,9 +573,6 @@
 (defn parent-ids
   [file]
   (into #{} (map :id (:parents file))))
-
-(def folder-mime-type
-  "application/vnd.google-apps.folder")
 
 (defn folder?
   [file]

--- a/src/google_apps_clj/repl.clj
+++ b/src/google_apps_clj/repl.clj
@@ -1,3 +1,3 @@
-(ns user
+(ns google-apps-clj.repl
   (:require [clojure.core.typed :as t]
             [google-apps-clj.google-drive :as gd]))

--- a/src/google_apps_clj/repl.clj
+++ b/src/google_apps_clj/repl.clj
@@ -1,3 +1,4 @@
 (ns google-apps-clj.repl
   (:require [clojure.core.typed :as t]
-            [google-apps-clj.google-drive :as gd]))
+            [google-apps-clj.google-drive :as gd]
+            [google-apps-clj.google-sheets :as gs]))

--- a/src/user.clj
+++ b/src/user.clj
@@ -1,0 +1,3 @@
+(ns user
+  (:require [clojure.core.typed :as t]
+            [google-apps-clj.google-drive :as gd]))

--- a/test/google_apps_clj/google_drive_test.clj
+++ b/test/google_apps_clj/google_drive_test.clj
@@ -5,30 +5,54 @@
 
 (deftest ^:integration test-scenario
   (let [creds (edn/read-string (slurp "google-creds.edn"))
+        q! (partial execute-query! creds)
         folder-name (name (gensym "google-apps-clj-google-drive-"))
         folder (create-folder! creds "root" folder-name)
-        folder-id (:id folder)]
-    (is folder-id)
-    (is (= folder-name (:title folder)))
-    (is (folder? folder))
+        folder-id (:id folder)
+        upload-request (upload-file folder-id
+                                    "test-title"
+                                    "test-description"
+                                    "text/plain"
+                                    (.getBytes "test-body" "UTF-8"))]
     (try
-      (let [file (upload-file! creds
-                               folder-id
-                               "test-title"
-                               "test-description"
-                               "text/plain"
-                               (.getBytes "test-body" "UTF-8"))
-            file-id (:id file)]
-        (is file-id)
-        (is (= "test-title" (:title file)))
-        (is (= "test-description" (:description file)))
-        (is (= "text/plain" (:mime-type file)))
-        (let [file' (get-file! creds file-id)]
-          (is (= "test-title" (:title file')))
-          (is (= "test-description" (:description file')))
-          (is (= "text/plain" (:mime-type file'))))
-        (let [files (list-files! creds folder-id)]
-          (is (= [file-id] (map :id files))))
-        (delete-file! creds file-id))
+      (testing "created a folder"
+        (is folder-id)
+        (is (= folder-name (:title folder)))
+        (is (folder? folder)))
+      (testing "uploads a file"
+        (let [file (execute-query! creds upload-request)
+              file-id (:id file)]
+          (is file-id)
+          (is (= "test-title" (:title file)))
+          (is (= "test-description" (:description file)))
+          (is (= "text/plain" (:mime-type file)))
+          (let [file' (get-file! creds file-id)]
+            (is (= "test-title" (:title file')))
+            (is (= "test-description" (:description file')))
+            (is (= "text/plain" (:mime-type file'))))
+          (let [files (list-files! creds folder-id)]
+            (is (= [file-id] (map :id files))))
+          (delete-file! creds file-id)))
+      (testing "file permissions"
+        (testing "in an unshared folder"
+          (let [folder (q! (-> (get-file folder-id)
+                               (with-fields [:permissions])))
+                {:keys [permissions]} folder]
+            (is (= [["owner" "user"]]
+                   (map (juxt :role :type) permissions)))))
+        (let [file (q! (-> upload-request
+                           (with-fields [:id :permissions])))
+              {:keys [id permissions]} file]
+          (is (= [["owner" "user"]]
+                 (map (juxt :role :type) permissions)))
+          (assign! creds {:file-id id
+                          :principal "dev@sparkfund.co"
+                          :role :reader})
+          (let [file (q! (-> (get-file id)
+                             (with-fields [:permissions])))
+                {:keys [permissions]} file]
+            (is (= [["owner" "user"]
+                    ["reader" "group"]]
+                   (map (juxt :role :type) permissions))))))
       (finally
         (delete-file! creds folder-id)))))

--- a/test/google_apps_clj/google_drive_test.clj
+++ b/test/google_apps_clj/google_drive_test.clj
@@ -1,0 +1,32 @@
+(ns google-apps-clj.google-drive-test
+  (:require [clojure.edn :as edn]
+            [clojure.test :refer :all]
+            [google-apps-clj.google-drive :refer :all]))
+
+(deftest ^:integration test-scenario
+  (let [creds (edn/read-string (slurp "google-creds.edn"))
+        folder-name (name (gensym "google-apps-clj-google-drive-"))
+        folder (create-folder! creds "root" folder-name)
+        folder-id (:id folder)]
+    (is folder-id)
+    (is (= folder-name (:title folder)))
+    (is (folder? folder))
+    (try
+      (let [file (upload-file! creds
+                               folder-id
+                               "test-title"
+                               "test-description"
+                               "text/plain"
+                               (.getBytes "test-body" "UTF-8"))
+            file-id (:id file)]
+        (is file-id)
+        (is (= "test-title" (:title file)))
+        (is (= "test-description" (:description file)))
+        (is (= "text/plain" (:mime-type file)))
+        (let [file' (get-file! creds file-id)]
+          (is (= "test-title" (:title file')))
+          (is (= "test-description" (:description file')))
+          (is (= "text/plain" (:mime-type file'))))
+        (delete-file! creds file-id))
+      (finally
+        (delete-file! creds folder-id)))))

--- a/test/google_apps_clj/google_drive_test.clj
+++ b/test/google_apps_clj/google_drive_test.clj
@@ -25,11 +25,12 @@
           (is file-id)
           (is (= "test-title" (:title file)))
           (is (= "test-description" (:description file)))
-          (is (= "text/plain" (:mime-type file)))
+          (testing "converts files when possible"
+            (is (= "application/vnd.google-apps.document" (:mime-type file))))
           (let [file' (get-file! creds file-id)]
             (is (= "test-title" (:title file')))
             (is (= "test-description" (:description file')))
-            (is (= "text/plain" (:mime-type file'))))
+            (is (= "application/vnd.google-apps.document" (:mime-type file'))))
           (let [files (list-files! creds folder-id)]
             (is (= [file-id] (map :id files))))
           (delete-file! creds file-id)))

--- a/test/google_apps_clj/google_drive_test.clj
+++ b/test/google_apps_clj/google_drive_test.clj
@@ -27,6 +27,8 @@
           (is (= "test-title" (:title file')))
           (is (= "test-description" (:description file')))
           (is (= "text/plain" (:mime-type file'))))
+        (let [files (list-files! creds folder-id)]
+          (is (= [file-id] (map :id files))))
         (delete-file! creds file-id))
       (finally
         (delete-file! creds folder-id)))))

--- a/test/google_apps_clj/google_drive_test.clj
+++ b/test/google_apps_clj/google_drive_test.clj
@@ -53,6 +53,9 @@
                                     :searchable? false})
             (is (= [["owner" "user"]
                     ["writer" "group"]]
+                   (map (juxt :role :type) (get-permissions! creds file-id))))
+            (revoke! creds file-id "dev@sparkfund.co")
+            (is (= [["owner" "user"]]
                    (map (juxt :role :type) (get-permissions! creds file-id)))))))
       (finally
         (delete-file! creds folder-id)))))

--- a/test/google_apps_clj/google_drive_test.clj
+++ b/test/google_apps_clj/google_drive_test.clj
@@ -4,7 +4,8 @@
             [google-apps-clj.google-drive :refer :all]))
 
 (deftest ^:integration test-scenario
-  (let [creds (edn/read-string (slurp "google-creds.edn"))
+  (let [creds (assoc (edn/read-string (slurp "google-creds.edn"))
+                     :read-timeout 60000)
         q! (partial execute-query! creds)
         folder-name (name (gensym "google-apps-clj-google-drive-"))
         folder (create-folder! creds "root" folder-name)
@@ -15,6 +16,7 @@
                                     "text/plain"
                                     (.getBytes "test-body" "UTF-8"))]
     (try
+      (prn "test run" folder-name)
       (testing "created a folder"
         (is folder-id)
         (is (= folder-name (:title folder)))
@@ -37,26 +39,66 @@
       (testing "file permissions"
         (testing "in an unshared folder"
           (is (= [["owner" "user"]]
-                 (map (juxt :role :type) (get-permissions! creds folder-id)))))
-        (let [file-id (:id (q! upload-request))]
-          (testing "newly created files have only the owner permission"
-            (is (= [["owner" "user"]]
-                   (map (juxt :role :type) (get-permissions! creds file-id)))))
-          (testing "managing authorization"
-            (assign! creds file-id {:principal "dev@sparkfund.co"
-                                    :role :reader
-                                    :searchable? false})
-            (is (= [["owner" "user"]
-                    ["reader" "group"]]
-                   (map (juxt :role :type) (get-permissions! creds file-id))))
-            (assign! creds file-id {:principal "dev@sparkfund.co"
+                 (map (juxt :role :type) (get-permissions! creds folder-id))))
+          (let [file-id (:id (q! upload-request))]
+            (testing "newly created files have only the owner permission"
+              (is (= [["owner" "user"]]
+                     (map (juxt :role :type) (get-permissions! creds file-id)))))
+            (testing "managing authorization"
+              (assign! creds file-id {:principal "dev@sparkfund.co"
+                                      :role :reader
+                                      :searchable? false})
+              (Thread/sleep 5000)
+              (is (= [["owner" "user"]
+                      ["reader" "group"]]
+                     (map (juxt :role :type) (get-permissions! creds file-id))))
+              (assign! creds file-id {:principal "dev@sparkfund.co"
+                                      :role :writer
+                                      :searchable? false})
+              (Thread/sleep 5000)
+              (is (= [["owner" "user"]
+                      ["writer" "group"]]
+                     (map (juxt :role :type) (get-permissions! creds file-id))))
+              (revoke! creds file-id "dev@sparkfund.co")
+              (Thread/sleep 5000)
+              (is (= [["owner" "user"]]
+                     (map (juxt :role :type) (get-permissions! creds file-id)))))))
+        (testing "in a shared folder"
+          (assign! creds folder-id {:principal "sparkfund.co"
                                     :role :writer
-                                    :searchable? false})
-            (is (= [["owner" "user"]
-                    ["writer" "group"]]
-                   (map (juxt :role :type) (get-permissions! creds file-id))))
-            (revoke! creds file-id "dev@sparkfund.co")
-            (is (= [["owner" "user"]]
-                   (map (juxt :role :type) (get-permissions! creds file-id)))))))
+                                    :searchable? true})
+          (Thread/sleep 5000)
+          (testing "files inherit their folder's permissions"
+            (let [file-id (:id (q! upload-request))]
+              (prn "file" file-id)
+              (is (= [["owner" "user"]
+                      ["writer"  "domain"]]
+                     (map (juxt :role :type) (get-permissions! creds file-id))))
+              (testing "and their changes"
+                (assign! creds folder-id {:principal "sparkfund.co"
+                                          :role :reader
+                                          :searchable? true})
+                (Thread/sleep 30000)
+                (prn "checking folder")
+                (is (= [["owner" "user"]
+                        ["reader"  "domain"]]
+                       (map (juxt :role :type) (get-permissions! creds folder-id))))
+                (prn "checking file")
+                (is (= [["owner" "user"]
+                        ["reader"  "domain"]]
+                       (map (juxt :role :type) (get-permissions! creds file-id))))))
+            (let [file-id (:id (q! upload-request))]
+              (is (= [["owner" "user"]
+                      ["reader" "domain"]]
+                     (map (juxt :role :type) (get-permissions! creds file-id))))
+              (testing "files retain their folder's permissions when they assign"
+                (assign! creds file-id {:principal "dev@sparkfund.co"
+                                        :role :writer
+                                        :searchable? true})
+                (Thread/sleep 5000)
+                (is (= [["owner" "user"]
+                        ["reader" "domain"]
+                        ["writer" "group"]]
+                       (map (juxt :role :type) (get-permissions! creds file-id)))))))))
       (finally
-        (delete-file! creds folder-id)))))
+        #_(delete-file! creds folder-id)))))


### PR DESCRIPTION
The former allows evaluation in single and batch execution modes with no difference in representation. Doing that also allows for transparent resolution of paginated results. Those are fetched eagerly; they could be fetched lazily, though I have issues with lazy seqs whose realization may be affected by network exceptions.

This also begins to add a higher-level authorization api with assign! and revoke! fns, hoping to provide a useful simplification of the oddities of the underlying permissions api.

If we like this direction, the next steps will be to write some gross integration tests and look at rewriting the extant fns in these terms.
