### PR TITLE
Develop

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,8 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/core.typed "0.3.14"]
+                 [http-kit "2.1.18"]
+                 [org.clojure/data.json "0.2.6"]
                  [com.google.apis/google-api-services-calendar "v3-rev128-1.20.0"]
                  [com.google.apis/google-api-services-drive "v2-rev168-1.20.0"]
                  [com.google.gdata/core "1.47.1"]]

--- a/src/google_apps_clj/credentials.clj
+++ b/src/google_apps_clj/credentials.clj
@@ -14,13 +14,15 @@
            (com.google.api.client.json JsonFactory)
            (com.google.api.client.json.jackson2 JacksonFactory)))
 
+(t/defalias AuthMap '{:access-token  String
+                      :expires-in    Number
+                      :refresh-token String
+                      :token-type    String})
+
 (t/defalias GoogleCtx '{:client-id       String
                         :client-secret   String
                         :redirect-uris   '[String]
-                        :auth-map        '{:access-token  String
-                                           :expires-in    Number
-                                           :refresh-token String
-                                           :token-type    String}
+                        :auth-map        AuthMap
                         :connect-timeout (t/Option Long)
                         :read-timeout    (t/Option Long)
                         :access-type     (t/Option String)
@@ -48,7 +50,6 @@
                         (.setInstalled details))]
     google-secret))
 
-(t/ann get-user-auth-code [GoogleCtx -> GoogleClientSecrets])
 (defn- get-user-auth-code [google-ctx scope]
   (let [baseurl "https://accounts.google.com/o/oauth2/v2/auth"
         code "response_type=code"
@@ -67,6 +68,7 @@
              (fn [[key val]] [(keyword (clojure.string/replace (name key) "_" "-")) val])
              map-in)))
 
+(t/ann get-auth-map [GoogleCtx -> AuthMap])
 (defn get-auth-map
   "Given a google-ctx configuration map, and a list of scopes(as strings),
    creates a URL for the user to receive their auth-code, which is then used
@@ -84,6 +86,7 @@
       (underscore-to-dash-in-keys (json/read-json (:body response)))
       (println "Authentication request failed, dumping response:" response))))
 
+(t/ann refresh-google-token [GoogleCtx -> AuthMap])
 (defn refresh-google-token [google-ctx]
   (let [base-url "https://www.googleapis.com/oauth2/v4/token"
         body {:refresh_token (get-in google-ctx [:auth-map :refresh-token])

--- a/src/google_apps_clj/credentials.clj
+++ b/src/google_apps_clj/credentials.clj
@@ -19,7 +19,7 @@
                                         :expires-in    t/AnyInteger
                                         :refresh-token t/Str
                                         :token-type    t/Str}
-                            :complete? true)
+                            :complete? true))
 
 (t/defalias GoogleCtx
   (t/HMap :mandatory {:client-id     t/Str

--- a/src/google_apps_clj/credentials.clj
+++ b/src/google_apps_clj/credentials.clj
@@ -87,15 +87,19 @@
       (println "Authentication request failed, dumping response:" response))))
 
 (t/ann refresh-google-token [GoogleCtx -> AuthMap])
-(defn refresh-google-token [google-ctx]
+(defn refresh-google-token
+  "Given a google-ctx configuration map containing a refresh token in the :auth-map,
+   returns an updated :auth-map with a refreshed access-token."
+  [google-ctx]
   (let [base-url "https://www.googleapis.com/oauth2/v4/token"
-        body {:refresh_token (get-in google-ctx [:auth-map :refresh-token])
+        refresh-token (get-in google-ctx [:auth-map :refresh-token])
+        body {:refresh_token refresh-token
               :client_id     (:client-id google-ctx)
               :client_secret (:client-secret google-ctx)
               :grant_type    "refresh_token"}
         response (deref (http/post base-url {:form-params body}) 5000 {:status "TIMEOUT AFTER 5 SECONDS"})]
     (if (= 200 (:status response))
-      (underscore-to-dash-in-keys (json/read-json (:body response)))
+      (assoc (underscore-to-dash-in-keys (json/read-json (:body response))) :refresh-token refresh-token)
       (println "Token refresh request failed, dumping response:" response))))
 
 (t/ann get-token-response [GoogleCtx -> GoogleTokenResponse])

--- a/src/google_apps_clj/credentials.clj
+++ b/src/google_apps_clj/credentials.clj
@@ -1,13 +1,11 @@
 (ns google-apps-clj.credentials
   "A library used to set up Google OAuth 2 credentials"
   (:require [clojure.core.typed :as t]
-            [clojure.edn :as edn :only [read-string]])
-  (:import (com.google.api.client.auth.oauth2 Credential
-                                              TokenResponse)
-           (com.google.api.client.googleapis.auth.oauth2 GoogleAuthorizationCodeFlow$Builder
-                                                         GoogleClientSecrets
+            [clojure.edn :as edn :only [read-string]]
+            [clojure.data.json :as json]
+            [org.httpkit.client :as http])
+  (:import (com.google.api.client.googleapis.auth.oauth2 GoogleClientSecrets
                                                          GoogleClientSecrets$Details
-                                                         GoogleCredential
                                                          GoogleCredential$Builder
                                                          GoogleTokenResponse)
            (com.google.api.client.googleapis.javanet GoogleNetHttpTransport)
@@ -16,15 +14,17 @@
            (com.google.api.client.json JsonFactory)
            (com.google.api.client.json.jackson2 JacksonFactory)))
 
-(t/defalias GoogleCtx '{:client-id String
-                        :client-secret String
-                        :redirect-uris '[String]
-                        :auth-map '{:access-token String
-                                    :expires-in Number
-                                    :refresh-token String
-                                    :token-type String}
+(t/defalias GoogleCtx '{:client-id       String
+                        :client-secret   String
+                        :redirect-uris   '[String]
+                        :auth-map        '{:access-token  String
+                                           :expires-in    Number
+                                           :refresh-token String
+                                           :token-type    String}
                         :connect-timeout (t/Option Long)
-                        :read-timeout (t/Option Long)})
+                        :read-timeout    (t/Option Long)
+                        :access-type     (t/Option String)
+                        :redirect-uri    (t/Option String)})
 
 (t/non-nil-return com.google.api.client.json.jackson2.JacksonFactory/getDefaultInstance :all)
 (t/non-nil-return com.google.api.client.googleapis.javanet.GoogleNetHttpTransport/newTrustedTransport :all)
@@ -48,31 +48,41 @@
                         (.setInstalled details))]
     google-secret))
 
-(t/ann get-auth-map [GoogleCtx (java.util.Collection String) -> TokenResponse])
+(t/ann get-user-auth-code [GoogleCtx -> GoogleClientSecrets])
+(defn- get-user-auth-code [google-ctx scope]
+  (let [baseurl "https://accounts.google.com/o/oauth2/v2/auth"
+        code "response_type=code"
+        scope (str "scope=" (clojure.string/join "%20" scope))
+        client-id (str "client_id=" (:client-id google-ctx))
+        acc-type (str "access_type=" (:access-type google-ctx "offline"))
+        redirect_uri (str "redirect_uri=" (:redirect-uri google-ctx "urn:ietf:wg:oauth:2.0:oob"))
+        args (str "?" code "&" scope "&" client-id "&" acc-type "&" redirect_uri)
+        auth-url (str baseurl args)]
+    (println "Please visit the following url and input the code "
+             "that appears on the screen: " auth-url)
+    (read-line)))
+
+(defn- underscore-to-dash-in-keys [map-in]
+  (into {} (map
+             (fn [[key val]] [(keyword (clojure.string/replace (name key) "_" "-")) val])
+             map-in)))
+
 (defn get-auth-map
   "Given a google-ctx configuration map, and a list of scopes(as strings),
    creates a URL for the user to receive their auth-code, which is then used
    to receive an authorization map, which the user should store securely"
   [google-ctx scope]
-  (let [google-secret (get-google-secret google-ctx)
-        auth-flow-builder (doto (GoogleAuthorizationCodeFlow$Builder. http-transport json-factory
-                                                                      google-secret scope)
-                            (.setAccessType "offline"))
-        auth-flow (doto (.build auth-flow-builder)
-                    assert)
-        auth-request-url (doto (.newAuthorizationUrl auth-flow)
-                           assert
-                           (.setRedirectUri "urn:ietf:wg:oauth:2.0:oob"))
-        auth-url (.build auth-request-url)
-        _ (println "Please visit the following url and input the code "
-                   "that appears on the screen: " auth-url)
-        auth-code (doto (read-line)
-                    assert)
-        token-request (doto (.newTokenRequest auth-flow auth-code)
-                        assert
-                        (.setRedirectUri "urn:ietf:wg:oauth:2.0:oob"))]
-    (doto (.execute token-request)
-      assert)))
+  (let [base-url "https://www.googleapis.com/oauth2/v4/token"
+        auth-code (get-user-auth-code google-ctx scope)
+        body {:code          auth-code
+              :client_id     (:client-id google-ctx)
+              :client_secret (:client-secret google-ctx)
+              :grant_type    "authorization_code"
+              :redirect_uri  (:redirect-uri google-ctx "urn:ietf:wg:oauth:2.0:oob")}
+        response (deref (http/post base-url {:form-params body}) 5000 {:status "TIMEOUT AFTER 5 SECONDS"})]
+    (if (= 200 (:status response))
+      (underscore-to-dash-in-keys (json/read-json (:body response)))
+      (println "Authentication request failed, dumping response:" response))))
 
 (t/ann get-token-response [GoogleCtx -> GoogleTokenResponse])
 (defn get-token-response

--- a/src/google_apps_clj/credentials.clj
+++ b/src/google_apps_clj/credentials.clj
@@ -84,6 +84,17 @@
       (underscore-to-dash-in-keys (json/read-json (:body response)))
       (println "Authentication request failed, dumping response:" response))))
 
+(defn refresh-google-token [google-ctx]
+  (let [base-url "https://www.googleapis.com/oauth2/v4/token"
+        body {:refresh_token (get-in google-ctx [:auth-map :refresh-token])
+              :client_id     (:client-id google-ctx)
+              :client_secret (:client-secret google-ctx)
+              :grant_type    "refresh_token"}
+        response (deref (http/post base-url {:form-params body}) 5000 {:status "TIMEOUT AFTER 5 SECONDS"})]
+    (if (= 200 (:status response))
+      (underscore-to-dash-in-keys (json/read-json (:body response)))
+      (println "Token refresh request failed, dumping response:" response))))
+
 (t/ann get-token-response [GoogleCtx -> GoogleTokenResponse])
 (defn get-token-response
   "Given a google-ctx configuration map, creates a GoogleTokenResponse Object


### PR DESCRIPTION
I rewrote the get-auth-map function to use Google REST API (instead of Java interop) and added a new type for AuthMap, which is returned by that function now. This also converts the json returned by google with keys like "access_token" to a proper clojure map with the key :access-token, which is what is expected in GoogleCtx. I'm using HTTPkit to send the requests and clojure.data.json to parse the json response. HTTPkit can easily be replaced by whatever other library you'd prefer to send HTTP requests, but it works pretty well.
Furthermore, I added a function to refresh an existing google token, which also returns an AuthMap containing the new token.
Users can also specify their own redirect-url, instead of always using copy paste, this enables you to have google send the auth-code directly to your web app. Consequently, you may also now specify your access-type as "online" or "offline". Both values are read from the google-context, defaulting to the previous functionality if none are given.

PS: Sorry for the messy commits, I worked on the master branch and then merged to develop. If you want you can also merge the master branch directly.
