### PR TITLE
Enable use of service account credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,38 @@ In order to use any of these APIs, you must first use the Google OAuth 2.0 libra
 10. Copy the returned data into your google-creds.edn file under the `:auth-map` key. Reload it into your REPL.
 11. You are now ready to use the other APIs with your credential file
 
+### Using Service Account Credentials
+
+Google also supports [Service Account credentials](https://developers.google.com/identity/protocols/OAuth2ServiceAccount)
+for server-to-server API access.  The credential is provided as a JSON file containing a private key and some other data.
+
+To obtain a service credential:
+
+1. Log in to Google using the account you wish the credentials to be under
+2. Navigate to the [Developer's Console](https://console.developers.google.com)
+3. Create a project and name it appropriately
+4. Navigate to the [API Manager](https://console.developers.google.com/apis/library), and enable the APIs you need an disable the default-provided ones you don't need
+5. Navigate to the [_Permissions > Service Accounts_ page](https://console.developers.google.com/permissions/serviceaccounts)
+6. Create a new service account, selecting the option to obtain a new private key as JSON.
+7. You should be given a JSON file containing the credential.  You have a few options now:
+  * Store it anywhere, and set an environment variable (`GOOGLE_APPLICATION_CREDENTIALS`) to point to it
+  * On Mac/Linux, rename and move the JSON file to be `~/.config/gcloud/application_default_credentials.json` (making directories as needed)
+  * On Windows, rename and move the JSON file to be `%APPDATA%\gcloud\application_default_credentials.json` (making directories as needed)
+
+Now you can use `google-apps-clj.credentials/default-credential` to load these credentials, and then
+pass them into most places that might otherwise expect a `google-ctx`.  For example:
+
+```clj
+(let [scopes [com.google.api.services.drive.DriveScopes/DRIVE]
+      creds (google-apps-clj.credentials/default-credential scopes)]
+    (google-apps-clj.google-drive/list-files! creds "FOLDERIDFOLDERIDFOLDERIDFOLD"))
+```
+
+(note in this scenario that the service account user has to be given the appropriate permissions in Drive.
+The service account user won't show up by name in searches, but it can be added as a viewer/editor using its
+`USERID@PROJECTID.iam.gserviceaccount.com` email address as found in the JSON credential file)
+
+
 ### Drive API
 
 ##### Supported Functionality

--- a/README.md
+++ b/README.md
@@ -106,8 +106,6 @@ The service account user won't show up by name in searches, but it can be added 
 
 #### General
 
-* Allow service account authentication in addition to the current
-  user-account OAuth funkiness
 * Consider ditching the baroque Google java library in favor of
   direct integration with the api using clj-http or the like
 

--- a/src/google_apps_clj/credentials.clj
+++ b/src/google_apps_clj/credentials.clj
@@ -107,20 +107,6 @@
   ([scopes]
    (credential-with-scopes (default-credential) (set scopes))))
 
-(t/ann ^:no-check build-credential [(t/U GoogleCtx GoogleCredential) -> HttpRequestInitializer])
-(defn build-credential
-  "Given a google-ctx configuration map, builds a GoogleCredential Object from
-   the token response and google secret created from those respective methods.
-   If an instance of GoogleCredential is provided, it will be returned unmodified"
-  [google-ctx]
-   (cond
-     ;pass through instances of GoogleCredential
-     (instance? GoogleCredential google-ctx)
-     google-ctx
-     ;construct the credential from the provided context
-     :otherwise
-     (build-credential-from-ctx google-ctx)))
-
 (t/ann ^:no-check build-credential-from-ctx [GoogleCtx -> HttpRequestInitializer])
 (defn- build-credential-from-ctx
   "Constructs a GoogleCredential from the token response and Google secret as obtained
@@ -145,6 +131,20 @@
           (when read-timeout
             (.setReadTimeout request read-timeout))))
       credential)))
+
+(t/ann ^:no-check build-credential [(t/U GoogleCtx GoogleCredential) -> HttpRequestInitializer])
+(defn build-credential
+  "Given a google-ctx configuration map, builds a GoogleCredential Object from
+   the token response and google secret created from those respective methods.
+   If an instance of GoogleCredential is provided, it will be returned unmodified"
+  [google-ctx]
+  (cond
+    ;pass through instances of GoogleCredential
+    (instance? GoogleCredential google-ctx)
+    google-ctx
+    ;construct the credential from the provided context
+    :otherwise
+    (build-credential-from-ctx google-ctx)))
 
 (t/ann credential-from-json-stream [t/Any -> GoogleCredential])
 (defn credential-from-json-stream

--- a/src/google_apps_clj/credentials.clj
+++ b/src/google_apps_clj/credentials.clj
@@ -30,6 +30,8 @@
           :optional {:connect-timeout t/AnyInteger
                      :read-timeout t/AnyInteger}))
 
+(t/defalias GoogleAuth (t/U GoogleCtx GoogleCredential))
+
 (t/non-nil-return com.google.api.client.json.jackson2.JacksonFactory/getDefaultInstance :all)
 (t/non-nil-return com.google.api.client.googleapis.javanet.GoogleNetHttpTransport/newTrustedTransport :all)
 
@@ -132,7 +134,7 @@
             (.setReadTimeout request read-timeout))))
       credential)))
 
-(t/ann ^:no-check build-credential [(t/U GoogleCtx GoogleCredential) -> HttpRequestInitializer])
+(t/ann ^:no-check build-credential [GoogleAuth -> HttpRequestInitializer])
 (defn build-credential
   "Given a google-ctx configuration map, builds a GoogleCredential Object from
    the token response and google secret created from those respective methods.

--- a/src/google_apps_clj/google_calendar.clj
+++ b/src/google_apps_clj/google_calendar.clj
@@ -14,7 +14,7 @@
                                              CalendarScopes)
            (com.google.api.client.googleapis.auth.oauth2 GoogleCredential)))
 
-(t/ann build-calendar-service [(t/U cred/GoogleCtx GoogleCredential) -> Calendar])
+(t/ann build-calendar-service [cred/GoogleAuth -> Calendar])
 (defn build-calendar-service
   "Given a google-ctx configuration map, builds a Calendar service using
   credentials coming from the OAuth2.0 credential setup inside googlectx"
@@ -25,7 +25,7 @@
     (cast Calendar (doto (.build calendar-builder)
                      assert))))
 
-(t/ann add-calendar-event [(t/U cred/GoogleCtx GoogleCredential) String String String String String (t/Coll String) Boolean -> Event])
+(t/ann add-calendar-event [cred/GoogleAuth String String String String String (t/Coll String) Boolean -> Event])
 (defn- add-calendar-event
   "Given a google-ctx configuration map, a title, a description, a location, a start and
    end time (in either YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS(+ or - hours off GMT like 4:00)),
@@ -63,7 +63,7 @@
     (cast Event (doto (.execute insert-request)
                   assert))))
 
-(t/ann add-calendar-time-event [(t/U cred/GoogleCtx GoogleCredential) String String String String String (t/Coll String) -> Event])
+(t/ann add-calendar-time-event [cred/GoogleAuth String String String String String (t/Coll String) -> Event])
 (defn add-calendar-time-event
   "Given a google-ctx configuration map, a title, a description, a location,
    a start and end time (in YYYY-MM-DDTHH:MM:SS(+ or - hours off GMT like 4:00)),
@@ -72,7 +72,7 @@
   [google-ctx title description location start-time end-time attendees]
   (add-calendar-event google-ctx title description location start-time end-time attendees false))
 
-(t/ann add-calendar-day-event [(t/U cred/GoogleCtx GoogleCredential) String String String String String (t/Coll String) -> Event])
+(t/ann add-calendar-day-event [cred/GoogleAuth String String String String String (t/Coll String) -> Event])
 (defn add-calendar-day-event
   "Given a google-ctx configuration map, a title, a description, a location,
    a start and end time (in YYYY-MM-DD), and a list of attendees email addresses,
@@ -80,7 +80,7 @@
   [google-ctx title description location start-time end-time attendees]
   (add-calendar-event google-ctx title description location start-time end-time attendees true))
 
-(t/ann list-events [(t/U cred/GoogleCtx GoogleCredential) String String -> (t/Seq Event)])
+(t/ann list-events [cred/GoogleAuth String String -> (t/Seq Event)])
 (defn list-events
   "Given a google-ctx configuration map, a start time and an end time
    (in YYYY-MM-DDTHH:MM:SS(+ or - hours off GMT like 4:00)),
@@ -103,7 +103,7 @@
                                      assert)
                                    (t/Seq Event))))
 
-(t/ann list-day-events [(t/U cred/GoogleCtx GoogleCredential) String String -> (t/Seq Event)])
+(t/ann list-day-events [cred/GoogleAuth String String -> (t/Seq Event)])
 (defn list-day-events
   "Given a google-ctx configuration map, a day in the form(YYYY-MM-DD),
    and an offset from the GMT time zone(in the form + or - 04 or 11, etc),
@@ -113,7 +113,7 @@
         end-time (str day "T23:59:59" time-zone-offset ":00")]
     (list-events google-ctx start-time end-time)))
 
-(t/ann list-events-by-name [(t/U cred/GoogleCtx GoogleCredential) String Number -> (t/Seq Event)])
+(t/ann list-events-by-name [cred/GoogleAuth String Number -> (t/Seq Event)])
 (defn list-events-by-name
   "Given a google-ctx configuration map, a title that will be the query
    of the event(this could be an email, title, description), and the max 

--- a/src/google_apps_clj/google_calendar.clj
+++ b/src/google_apps_clj/google_calendar.clj
@@ -11,9 +11,10 @@
            (com.google.api.services.calendar Calendar
                                              Calendar$Builder
                                              Calendar$Events$Insert
-                                             CalendarScopes)))
+                                             CalendarScopes)
+           (com.google.api.client.googleapis.auth.oauth2 GoogleCredential)))
 
-(t/ann build-calendar-service [cred/GoogleCtx -> Calendar])
+(t/ann build-calendar-service [(t/U cred/GoogleCtx GoogleCredential) -> Calendar])
 (defn build-calendar-service
   "Given a google-ctx configuration map, builds a Calendar service using
   credentials coming from the OAuth2.0 credential setup inside googlectx"
@@ -24,7 +25,7 @@
     (cast Calendar (doto (.build calendar-builder)
                      assert))))
 
-(t/ann add-calendar-event [cred/GoogleCtx String String String String String (t/Coll String) Boolean -> Event])
+(t/ann add-calendar-event [(t/U cred/GoogleCtx GoogleCredential) String String String String String (t/Coll String) Boolean -> Event])
 (defn- add-calendar-event
   "Given a google-ctx configuration map, a title, a description, a location, a start and
    end time (in either YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS(+ or - hours off GMT like 4:00)),
@@ -62,7 +63,7 @@
     (cast Event (doto (.execute insert-request)
                   assert))))
 
-(t/ann add-calendar-time-event [cred/GoogleCtx String String String String String (t/Coll String) -> Event])
+(t/ann add-calendar-time-event [(t/U cred/GoogleCtx GoogleCredential) String String String String String (t/Coll String) -> Event])
 (defn add-calendar-time-event
   "Given a google-ctx configuration map, a title, a description, a location,
    a start and end time (in YYYY-MM-DDTHH:MM:SS(+ or - hours off GMT like 4:00)),
@@ -71,7 +72,7 @@
   [google-ctx title description location start-time end-time attendees]
   (add-calendar-event google-ctx title description location start-time end-time attendees false))
 
-(t/ann add-calendar-day-event [cred/GoogleCtx String String String String String (t/Coll String) -> Event])
+(t/ann add-calendar-day-event [(t/U cred/GoogleCtx GoogleCredential) String String String String String (t/Coll String) -> Event])
 (defn add-calendar-day-event
   "Given a google-ctx configuration map, a title, a description, a location,
    a start and end time (in YYYY-MM-DD), and a list of attendees email addresses,
@@ -79,7 +80,7 @@
   [google-ctx title description location start-time end-time attendees]
   (add-calendar-event google-ctx title description location start-time end-time attendees true))
 
-(t/ann list-events [cred/GoogleCtx String String -> (t/Seq Event)])
+(t/ann list-events [(t/U cred/GoogleCtx GoogleCredential) String String -> (t/Seq Event)])
 (defn list-events
   "Given a google-ctx configuration map, a start time and an end time
    (in YYYY-MM-DDTHH:MM:SS(+ or - hours off GMT like 4:00)),
@@ -102,7 +103,7 @@
                                      assert)
                                    (t/Seq Event))))
 
-(t/ann list-day-events [cred/GoogleCtx String String -> (t/Seq Event)])
+(t/ann list-day-events [(t/U cred/GoogleCtx GoogleCredential) String String -> (t/Seq Event)])
 (defn list-day-events
   "Given a google-ctx configuration map, a day in the form(YYYY-MM-DD),
    and an offset from the GMT time zone(in the form + or - 04 or 11, etc),
@@ -112,7 +113,7 @@
         end-time (str day "T23:59:59" time-zone-offset ":00")]
     (list-events google-ctx start-time end-time)))
 
-(t/ann list-events-by-name [cred/GoogleCtx String Number -> (t/Seq Event)])
+(t/ann list-events-by-name [(t/U cred/GoogleCtx GoogleCredential) String Number -> (t/Seq Event)])
 (defn list-events-by-name
   "Given a google-ctx configuration map, a title that will be the query
    of the event(this could be an email, title, description), and the max 

--- a/src/google_apps_clj/google_drive.clj
+++ b/src/google_apps_clj/google_drive.clj
@@ -59,7 +59,7 @@
 (t/non-nil-return com.google.api.services.drive.Drive$Permissions/list :all)
 (t/non-nil-return com.google.api.services.drive.Drive$Permissions/update :all)
 
-(t/ann build-drive-service [(t/U cred/GoogleCtx GoogleCredential) -> Drive])
+(t/ann build-drive-service [cred/GoogleAuth -> Drive])
 (defn ^Drive build-drive-service
   "Given a google-ctx configuration map, builds a Drive service using
    credentials coming from the OAuth2.0 credential setup inside google-ctx"
@@ -228,7 +228,7 @@
       (cond-doto (InputStreamContent. ^String mime-type (io/input-stream content))
         size (.setLength ^Long size)))))
 
-(t/ann build-request [(t/U cred/GoogleCtx GoogleCredential) Query -> Request])
+(t/ann build-request [cred/GoogleAuth Query -> Request])
 (defn- ^DriveRequest build-request
   "Converts a query into a stateful request object executable in the
    given google context. Queries are maps with the following required

--- a/src/google_apps_clj/google_drive.clj
+++ b/src/google_apps_clj/google_drive.clj
@@ -37,7 +37,8 @@
                                                 Property
                                                 PropertyList
                                                 User)
-           (java.io InputStream)))
+           (java.io InputStream)
+           (com.google.api.client.googleapis.auth.oauth2 GoogleCredential)))
 
 ;;; TODO this does not type check now due to protocol (ab)use and general
 ;;; unfamiliarity with types when I first rewrote it
@@ -58,7 +59,7 @@
 (t/non-nil-return com.google.api.services.drive.Drive$Permissions/list :all)
 (t/non-nil-return com.google.api.services.drive.Drive$Permissions/update :all)
 
-(t/ann build-drive-service [cred/GoogleCtx -> Drive])
+(t/ann build-drive-service [(t/U cred/GoogleCtx GoogleCredential) -> Drive])
 (defn ^Drive build-drive-service
   "Given a google-ctx configuration map, builds a Drive service using
    credentials coming from the OAuth2.0 credential setup inside google-ctx"
@@ -227,7 +228,7 @@
       (cond-doto (InputStreamContent. ^String mime-type (io/input-stream content))
         size (.setLength ^Long size)))))
 
-(t/ann build-request [cred/GoogleCtx Query -> Request])
+(t/ann build-request [(t/U cred/GoogleCtx GoogleCredential) Query -> Request])
 (defn- ^DriveRequest build-request
   "Converts a query into a stateful request object executable in the
    given google context. Queries are maps with the following required

--- a/src/google_apps_clj/google_sheets.clj
+++ b/src/google_apps_clj/google_sheets.clj
@@ -20,14 +20,15 @@
                                                 SpreadsheetService
                                                 WorksheetQuery)
            (com.google.gdata.data.batch BatchOperationType
-                                        BatchUtils)))
+                                        BatchUtils)
+           (com.google.api.client.googleapis.auth.oauth2 GoogleCredential)))
 (t/ann ^:no-check clojure.java.io/as-url [t/Str -> java.net.URL])
 
 (def spreadsheet-url
   "The url needed and used to recieve a spreadsheet feed"
   (io/as-url "https://spreadsheets.google.com/feeds/spreadsheets/private/full"))
 
-(t/ann build-sheet-service [cred/GoogleCtx -> SpreadsheetService])
+(t/ann build-sheet-service [(t/U GoogleCtx GoogleCredential) -> SpreadsheetService])
 (defn build-sheet-service
   "Given a google-ctx configuration map, builds a SpreadsheetService using
    the credentials coming from google-ctx"
@@ -81,7 +82,7 @@
           (< (count entries) 1) {:error :no-spreadsheet}
           :else {:error :more-than-one-spreadsheet})))
 
-(t/ann ^:no-check file-name->ids [cred/GoogleCtx String -> (t/U '{:spreadsheet t/Map
+(t/ann ^:no-check file-name->ids [(t/U GoogleCtx GoogleCredential) String -> (t/U '{:spreadsheet t/Map
                                                                   :worksheet t/Map}
                                                                 '{:error t/Keyword})])
 (defn file-name->ids
@@ -109,7 +110,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (t/ann create-new-worksheet
-       [cred/GoogleCtx SpreadsheetEntry Number Number String -> WorksheetEntry])
+       [(t/U GoogleCtx GoogleCredential) SpreadsheetEntry Number Number String -> WorksheetEntry])
 (defn create-new-worksheet
   "Given a google-ctx configuration map, SpreadsheetEntry, rows, columns, and
    a title, create a new worksheet for for the SpreadsheetEntry with this data"
@@ -220,7 +221,7 @@
           :else {:error :more-than-one-cell})))
 
 (t/ann ^:no-check update-cell
-       [cred/GoogleCtx String String '[Number Number String] -> (t/U CellEntry
+       [(t/U GoogleCtx GoogleCredential) String String '[Number Number String] -> (t/U CellEntry
                                                                      '{:error t/Keyword})])
 (defn update-cell
   "Given a google-ctx configuration map, the id of a spreadsheet,
@@ -247,7 +248,7 @@
         (.update sheet-service cell-url cell)))))
 
 (t/ann ^:no-check insert-row
-       [cred/GoogleCtx String String (t/Seq (t/Map String String)) -> (t/U ListEntry
+       [(t/U GoogleCtx GoogleCredential) String String (t/Seq (t/Map String String)) -> (t/U ListEntry
                                                                            '{:error t/Keyword})])
 (defn insert-row
   "Given a google-ctx configuration map, the name of a spreadsheet,
@@ -279,7 +280,7 @@
           (.insert sheet-service (:list-feed-url list-feed-url) row)))))
 
 (t/ann ^:no-check batch-update-cells
-       [cred/GoogleCtx String String (t/Seq '[Number Number String]) -> (t/U CellFeed
+       [(t/U GoogleCtx GoogleCredential) String String (t/Seq '[Number Number String]) -> (t/U CellFeed
                                                                              '{:error t/Keyword})])
 (defn batch-update-cells
   "Given a google-ctx configuration map, the id of a spreadsheet, the id of
@@ -354,7 +355,7 @@
                         (into [] (map #(get-value row %) (.getTags row)))))]
     (map print-value entries)))
 
-(t/ann ^:no-check read-worksheet [cred/GoogleCtx String String -> (t/U '{:headers (t/Vec String)
+(t/ann ^:no-check read-worksheet [(t/U GoogleCtx GoogleCredential) String String -> (t/U '{:headers (t/Vec String)
                                                                          :values (t/Seq (t/Vec String))}
                                                                        '{:error t/Keyword})])
 (defn read-worksheet
@@ -374,7 +375,7 @@
         {:headers headers :values values}))))
 
 (t/ann ^:no-check write-worksheet
-       [cred/GoogleCtx String String '{:headers (t/Vec String)
+       [(t/U GoogleCtx GoogleCredential) String String '{:headers (t/Vec String)
                                       :values (t/Seq (t/Vec String))} -> (t/U '{:error t/Keyword}
                                                                               (t/Seq CellEntry))])
 (defn write-worksheet

--- a/src/google_apps_clj/google_sheets.clj
+++ b/src/google_apps_clj/google_sheets.clj
@@ -28,7 +28,7 @@
   "The url needed and used to recieve a spreadsheet feed"
   (io/as-url "https://spreadsheets.google.com/feeds/spreadsheets/private/full"))
 
-(t/ann build-sheet-service [(t/U GoogleCtx GoogleCredential) -> SpreadsheetService])
+(t/ann build-sheet-service [cred/GoogleAuth -> SpreadsheetService])
 (defn build-sheet-service
   "Given a google-ctx configuration map, builds a SpreadsheetService using
    the credentials coming from google-ctx"
@@ -82,7 +82,7 @@
           (< (count entries) 1) {:error :no-spreadsheet}
           :else {:error :more-than-one-spreadsheet})))
 
-(t/ann ^:no-check file-name->ids [(t/U GoogleCtx GoogleCredential) String -> (t/U '{:spreadsheet t/Map
+(t/ann ^:no-check file-name->ids [cred/GoogleAuth String -> (t/U '{:spreadsheet t/Map
                                                                   :worksheet t/Map}
                                                                 '{:error t/Keyword})])
 (defn file-name->ids
@@ -110,7 +110,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (t/ann create-new-worksheet
-       [(t/U GoogleCtx GoogleCredential) SpreadsheetEntry Number Number String -> WorksheetEntry])
+       [cred/GoogleAuth SpreadsheetEntry Number Number String -> WorksheetEntry])
 (defn create-new-worksheet
   "Given a google-ctx configuration map, SpreadsheetEntry, rows, columns, and
    a title, create a new worksheet for for the SpreadsheetEntry with this data"
@@ -221,7 +221,7 @@
           :else {:error :more-than-one-cell})))
 
 (t/ann ^:no-check update-cell
-       [(t/U GoogleCtx GoogleCredential) String String '[Number Number String] -> (t/U CellEntry
+       [cred/GoogleAuth String String '[Number Number String] -> (t/U CellEntry
                                                                      '{:error t/Keyword})])
 (defn update-cell
   "Given a google-ctx configuration map, the id of a spreadsheet,
@@ -248,7 +248,7 @@
         (.update sheet-service cell-url cell)))))
 
 (t/ann ^:no-check insert-row
-       [(t/U GoogleCtx GoogleCredential) String String (t/Seq (t/Map String String)) -> (t/U ListEntry
+       [cred/GoogleAuth String String (t/Seq (t/Map String String)) -> (t/U ListEntry
                                                                            '{:error t/Keyword})])
 (defn insert-row
   "Given a google-ctx configuration map, the name of a spreadsheet,
@@ -280,7 +280,7 @@
           (.insert sheet-service (:list-feed-url list-feed-url) row)))))
 
 (t/ann ^:no-check batch-update-cells
-       [(t/U GoogleCtx GoogleCredential) String String (t/Seq '[Number Number String]) -> (t/U CellFeed
+       [cred/GoogleAuth String String (t/Seq '[Number Number String]) -> (t/U CellFeed
                                                                              '{:error t/Keyword})])
 (defn batch-update-cells
   "Given a google-ctx configuration map, the id of a spreadsheet, the id of
@@ -355,7 +355,7 @@
                         (into [] (map #(get-value row %) (.getTags row)))))]
     (map print-value entries)))
 
-(t/ann ^:no-check read-worksheet [(t/U GoogleCtx GoogleCredential) String String -> (t/U '{:headers (t/Vec String)
+(t/ann ^:no-check read-worksheet [cred/GoogleAuth String String -> (t/U '{:headers (t/Vec String)
                                                                          :values (t/Seq (t/Vec String))}
                                                                        '{:error t/Keyword})])
 (defn read-worksheet
@@ -375,7 +375,7 @@
         {:headers headers :values values}))))
 
 (t/ann ^:no-check write-worksheet
-       [(t/U GoogleCtx GoogleCredential) String String '{:headers (t/Vec String)
+       [cred/GoogleAuth String String '{:headers (t/Vec String)
                                       :values (t/Seq (t/Vec String))} -> (t/U '{:error t/Keyword}
                                                                               (t/Seq CellEntry))])
 (defn write-worksheet


### PR DESCRIPTION
These changes are to allow for the use of service account credentials in place of user-granted OAuth credentials. This is useful for allowing automated services to interact with Google APIs.
