### PR TITLE
Revamp Drive APIs; squash type checking errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # google-apps-clj
 
-A Clojure library that wraps the Google Java API for different Google
-Applications. This library is partially typed using `core.typed`
+A Clojure library that wraps the Google Java API for different Google Applications.
+
+This library is partially typed using `core.typed`.  Run `lein typed check` to type-check the library's code.
 
 ## Installing
 

--- a/project.clj
+++ b/project.clj
@@ -9,8 +9,13 @@
                  [com.google.apis/google-api-services-drive "v2-rev168-1.20.0"]
                  [com.google.gdata/core "1.47.1" :exclusions [org.apache.httpcomponents/httpclient
                                                               com.google.code.findbugs/jsr305]]]
+  :plugins [[lein-typed "0.3.5"]]
   :repl-options {:init-ns google-apps-clj.repl}
   :test-selectors {:integration :integration
                    :all (constantly true)
                    :default (complement :integration)}
+  :core.typed {:check [google-apps-clj.credentials
+                       google-apps-clj.google-calendar
+                       google-apps-clj.google-drive
+                       google-apps-clj.google-sheets]}
   :pedantic? :abort)

--- a/src/google_apps_clj/credentials.clj
+++ b/src/google_apps_clj/credentials.clj
@@ -44,10 +44,10 @@
 (t/ann ^:no-check clojure.core/some? [t/Any -> t/Bool])
 
 (t/ann http-transport HttpTransport)
-(def http-transport (GoogleNetHttpTransport/newTrustedTransport))
+(def ^HttpTransport http-transport (GoogleNetHttpTransport/newTrustedTransport))
 
 (t/ann json-factory JsonFactory)
-(def json-factory (JacksonFactory/getDefaultInstance))
+(def ^JsonFactory json-factory (JacksonFactory/getDefaultInstance))
 
 
 (t/ann get-google-secret [GoogleCtx -> GoogleClientSecrets])
@@ -81,8 +81,7 @@
         auth-url (.build auth-request-url)
         _ (println "Please visit the following url and input the code "
                    "that appears on the screen: " auth-url)
-        auth-code (doto (read-line)
-                    assert)
+        auth-code (doto ^String (read-line) assert)
         token-request (doto (.newTokenRequest auth-flow auth-code)
                         assert
                         (.setRedirectUri "urn:ietf:wg:oauth:2.0:oob"))]
@@ -90,15 +89,18 @@
       assert)))
 
 (t/ann get-token-response [GoogleCtx -> GoogleTokenResponse])
-(defn get-token-response
+(defn ^GoogleTokenResponse get-token-response
   "Given a google-ctx configuration map, creates a GoogleTokenResponse Object
    by pulling data from the authorization map inside of the google-ctx"
   [google-ctx]
-  (let [auth-map (:auth-map google-ctx)]
+  (let [auth-map (:auth-map google-ctx)
+        access-token ^String (:access-token auth-map)
+        refresh-token ^String (:refresh-token auth-map)
+        token-type ^String (:token-type auth-map)]
     (doto (GoogleTokenResponse.)
-      (.setAccessToken (:access-token auth-map))
-      (.setRefreshToken (:refresh-token auth-map))
-      (.setTokenType (:token-type auth-map)))))
+      (.setAccessToken access-token)
+      (.setRefreshToken refresh-token)
+      (.setTokenType token-type))))
 
 (t/ann credential-with-scopes [GoogleCredential OAuthScopes -> GoogleCredential])
 (defn ^GoogleCredential credential-with-scopes
@@ -108,7 +110,7 @@
   (.createScoped cred (set scopes)))
 
 (t/ann credential-from-json-stream [t/Any -> GoogleCredential])
-(defn credential-from-json-stream
+(defn ^GoogleCredential credential-from-json-stream
   "Consumes an input stream containing JSON describing a Google API credential
   `stream` can be anything that can be handled by `clojure.java.io/input-stream`"
   [stream]
@@ -116,7 +118,7 @@
     (GoogleCredential/fromStream input-stream)))
 
 (t/ann credential-from-json [t/Str -> GoogleCredential])
-(defn credential-from-json
+(defn ^GoogleCredential credential-from-json
   "Builds a GoogleCredential from a raw JSON string describing a Google API credential"
   [^String cred-json]
   (let [charset (Charset/forName "UTF-8")

--- a/src/google_apps_clj/google_calendar.clj
+++ b/src/google_apps_clj/google_calendar.clj
@@ -7,7 +7,7 @@
   (:import (com.google.api.client.util DateTime)
            (com.google.api.services.calendar.model Event
                                                    EventAttendee
-                                                   EventDateTime)
+                                                   EventDateTime Events)
            (com.google.api.services.calendar Calendar
                                              Calendar$Builder
                                              Calendar$Events$Insert
@@ -99,7 +99,7 @@
                       (.setSingleEvents true))
         days-events (doto (.execute list-events)
                       assert)]
-    (tu/ignore-with-unchecked-cast (doto (.getItems days-events)
+    (tu/ignore-with-unchecked-cast (doto (.getItems ^Events days-events)
                                      assert)
                                    (t/Seq Event))))
 
@@ -133,6 +133,6 @@
                       (.setSingleEvents true))
         days-events (doto (.execute list-events)
                       assert)]
-    (tu/ignore-with-unchecked-cast (doto (.getItems days-events)
+    (tu/ignore-with-unchecked-cast (doto (.getItems ^Events days-events)
                                      assert)
                                    (t/Seq Event))))

--- a/src/google_apps_clj/google_drive.clj
+++ b/src/google_apps_clj/google_drive.clj
@@ -1,45 +1,43 @@
 (ns google-apps-clj.google-drive
   "A library for connecting to Google Drive through the Drive API"
-  (:require [clojure.core.typed :as t]
-            [clojure.java.io :as io]
-            [clojure.string :as string]
-            [google-apps-clj.credentials :as cred]
-            [google-apps-clj.google-drive.mime-types :as gdrive-mime]
-            [google-apps-clj.google-drive.constants :as gdrive-const])
-  (:import (com.google.api.client.googleapis.batch BatchRequest
-                                                   BatchCallback)
-           (com.google.api.client.googleapis.json GoogleJsonError
-                                                  GoogleJsonError$ErrorInfo
-                                                  GoogleJsonErrorContainer
-                                                  GoogleJsonResponseException)
-           (com.google.api.client.http FileContent
-                                       InputStreamContent
-                                       GenericUrl)
-           (com.google.api.client.util GenericData)
-           (com.google.api.services.drive Drive
-                                          Drive$Builder
-                                          Drive$Files$Delete
-                                          Drive$Files$Get
-                                          Drive$Files$Insert
-                                          Drive$Files$List
-                                          Drive$Files$Update
-                                          Drive$Permissions$Delete
-                                          Drive$Permissions$Insert
-                                          Drive$Permissions$List
-                                          Drive$Permissions$Update
-                                          DriveRequest
-                                          DriveScopes Drive$Permissions)
-           (com.google.api.services.drive.model File
-                                                File$Labels
-                                                FileList
-                                                ParentReference
-                                                Permission
-                                                PermissionList
-                                                Property
-                                                PropertyList
-                                                User)
-           (java.io InputStream)
-           (com.google.api.client.googleapis.auth.oauth2 GoogleCredential)))
+  (:require
+    [clojure.core.typed :as t]
+    [clojure.java.io :as io]
+    [clojure.string :as string]
+    [google-apps-clj.credentials :as cred]
+    [google-apps-clj.google-drive.mime-types :as gdrive-mime]
+    [google-apps-clj.google-drive.constants :as gdrive-const])
+  (:import
+    (com.google.api.client.googleapis.batch
+      BatchRequest
+      BatchCallback)
+    (com.google.api.client.googleapis.json
+      GoogleJsonError
+      GoogleJsonError$ErrorInfo
+      GoogleJsonErrorContainer
+      GoogleJsonResponseException)
+    (com.google.api.client.http
+      InputStreamContent
+      GenericUrl)
+    (com.google.api.services.drive
+      Drive
+      Drive$Builder
+      Drive$Files$Delete
+      Drive$Files$Get
+      Drive$Files$Insert
+      Drive$Files$List
+      Drive$Files$Update
+      Drive$Permissions$Delete
+      Drive$Permissions$Insert
+      Drive$Permissions$List
+      Drive$Permissions$Update
+      DriveRequest)
+    (com.google.api.services.drive.model
+      File
+      FileList
+      ParentReference
+      Permission
+      PermissionList)))
 
 ;;; TODO this does not type check now due to protocol (ab)use and general
 ;;; unfamiliarity with types when I first rewrote it

--- a/src/google_apps_clj/google_drive.clj
+++ b/src/google_apps_clj/google_drive.clj
@@ -596,9 +596,9 @@
       (case action
         :list (FileListQuery->DriveRequest drive-service query)
         :get (FileGetQuery->DriveRequest drive-service query)
-        :insert (FileInsertQuery->DriveRequest drive-service query))
-      :update (FileUpdateQuery->DriveRequest drive-service query)
-      :delete (FileDeleteQuery->DriveRequest drive-service query)
+        :insert (FileInsertQuery->DriveRequest drive-service query)
+        :update (FileUpdateQuery->DriveRequest drive-service query)
+        :delete (FileDeleteQuery->DriveRequest drive-service query))
       :permissions
       (case action
         :list (PermissionListQuery->DriveRequest drive-service query)

--- a/src/google_apps_clj/google_drive.clj
+++ b/src/google_apps_clj/google_drive.clj
@@ -509,7 +509,7 @@
     ;build up the Java permission object
     (.setValue permission value)
     (when role (.setRole permission (name role)))
-    (when type (.setType permission (name role)))
+    (when type (.setType permission (name type)))
     (when (some? with-link?) (.setWithLink permission (boolean with-link?)))
     ;now make the request
     (let [permission-svc (.permissions drive-service)

--- a/src/google_apps_clj/google_drive.clj
+++ b/src/google_apps_clj/google_drive.clj
@@ -572,19 +572,10 @@
 
 (t/ann Query->DriveRequest [Drive Query -> DriveRequest])
 (defn- ^DriveRequest Query->DriveRequest
-  "Converts a query into a stateful request object executable in the
-   given google context. Queries are maps with the following required
-   fields:
-
-   :model - :files, :permissions
-   :action - :list, :get, :update, :insert, :delete
-
-   Other fields may be given, and may be required by the action and model.
-   These may include:
-
-   :fields - a seq of keywords specifying the object projection
-   :query - used to constrain a list of files
-   :file-id - specifies the file for file-specific models and actions"
+  "Converts a Query map into an instance of DriveRequest.  All Query maps have at least
+  a `:model` and an `:action` key describing the type of operation that they represent.
+  The exact class returned depends on the `:model` and `:action` keys of the Query map,
+  but all returend classes are ones that implement DriveRequest."
   [drive-service query]
   (let [{:keys [model action]} query]
     (case model
@@ -601,7 +592,6 @@
         :insert (PermissionInsertQuery->DriveRequest drive-service query)
         :update (PermissionUpdateQuery->DriveRequest drive-service query)
         :delete (PermissionDeleteQuery->DriveRequest drive-service query)))))
-
 
 
 (defprotocol Requestable

--- a/src/google_apps_clj/google_drive.clj
+++ b/src/google_apps_clj/google_drive.clj
@@ -162,8 +162,8 @@
                 :file-id FileId
                 :role    Role
                 :type    PermissionType
-                :value   t/Str} ((
-                                                  :optional)) {:with-link? t/Bool
+                :value   t/Str}
+    :optional {:with-link? t/Bool
                :fields     FieldList}
     :complete? true))
 
@@ -257,7 +257,7 @@
     (nil? principal) nil
     (= "anyone" principal) :anyone
     ;This seems to work correctly for users and groups
-    (pos? (.indexOf principal "@")) :user
+    (> (.indexOf principal "@") 0) :user
     :else :domain))
 
 (defn- derive-principal
@@ -318,7 +318,7 @@
 
 (t/ann file-list-query (t/IFn [-> FileListQuery] [(t/HMap) -> FileListQuery]))
 (defn file-list-query
-  ([] (file-list-query []))
+  ([] (file-list-query {}))
   ([extras]
    (merge extras {:model :files, :action :list})))
 
@@ -592,11 +592,11 @@
     (case model
       :files
       (case action
-        :delete (FileDeleteQuery->DriveRequest drive-service query)
         :list   (FileListQuery->DriveRequest drive-service query)
         :get    (FileGetQuery->DriveRequest drive-service query)
-        :update (FileUpdateQuery->DriveRequest drive-service query)
         :insert (FileInsertQuery->DriveRequest drive-service query))
+        :update (FileUpdateQuery->DriveRequest drive-service query)
+        :delete (FileDeleteQuery->DriveRequest drive-service query)
       :permissions
       (case action
         :list   (PermissionListQuery->DriveRequest drive-service query)

--- a/src/google_apps_clj/google_drive.clj
+++ b/src/google_apps_clj/google_drive.clj
@@ -646,11 +646,9 @@
   (convert-response [m]
     (->> (keys m)
          (map (fn [^String field-name]
-                (let [value (convert-response (get m field-name))
-                      key (if-not (true? value)
-                            (-> field-name camel->kebab keyword)
-                            (-> field-name camel->kebab (str "?") keyword))]
-                  [key value])))
+                (let [k (keyword (camel->kebab field-name))
+                      v (convert-response (get m field-name))]
+                  [k v])))
          (into {})))
   com.google.api.client.util.ArrayMap
   (convert-response [m] m)

--- a/src/google_apps_clj/google_drive/constants.clj
+++ b/src/google_apps_clj/google_drive/constants.clj
@@ -1,0 +1,15 @@
+(ns google-apps-clj.google-drive.constants
+  "Documentation of miscellaneous Google Drive constants"
+  (:require [clojure.core.typed :as t]))
+
+(t/def batch-size
+  "Google internally unwraps batches and processes them concurrently. Batches
+   that are too large can cause the request to exceed Google's api rate limit,
+   which is applied to api requests, not http requests."
+  :- Long
+  20)
+
+(t/def root-folder-id
+  "The unique ID of the root folder of Google Drive"
+  :- t/Str
+  "root")

--- a/src/google_apps_clj/google_drive/mime_types.clj
+++ b/src/google_apps_clj/google_drive/mime_types.clj
@@ -1,0 +1,20 @@
+(ns google-apps-clj.google-drive.mime-types
+  "Documentation of the supported custom Google Drive mime-types
+  (from https://developers.google.com/drive/v3/web/mime-types)"
+  (:require [clojure.core.typed :as t]))
+
+(t/def audio        :- t/Str "application/vnd.google-apps.audio")
+(t/def document     :- t/Str "application/vnd.google-apps.document")
+(t/def drawing      :- t/Str "application/vnd.google-apps.drawing")
+(t/def file         :- t/Str "application/vnd.google-apps.file")
+(t/def folder       :- t/Str "application/vnd.google-apps.folder")
+(t/def form         :- t/Str "application/vnd.google-apps.form")
+(t/def fusion-table :- t/Str "application/vnd.google-apps.fusiontable")
+(t/def map-custom   :- t/Str "application/vnd.google-apps.map")
+(t/def photo        :- t/Str "application/vnd.google-apps.photo")
+(t/def presentation :- t/Str "application/vnd.google-apps.presentation")
+(t/def apps-script  :- t/Str "application/vnd.google-apps.script")
+(t/def sites        :- t/Str "application/vnd.google-apps.sites")
+(t/def spreadsheet  :- t/Str "application/vnd.google-apps.spreadsheet")
+(t/def unknown      :- t/Str "application/vnd.google-apps.unknown")
+(t/def video        :- t/Str "application/vnd.google-apps.video")

--- a/src/google_apps_clj/repl.clj
+++ b/src/google_apps_clj/repl.clj
@@ -1,5 +1,6 @@
 (ns google-apps-clj.repl
   (:require [clojure.core.typed :as t]
+            [google-apps-clj.credentials :as gauth]
             [google-apps-clj.google-calendar :as gcal]
             [google-apps-clj.google-drive :as gdrive]
             [google-apps-clj.google-sheets :as gsheets]))


### PR DESCRIPTION
This branch introduces a large number of breaking changes to the `google-apps-clj.google-drive` namespace in the first part of a larger effort to better organize and document the code.  It also squashes type checking errors across the entire codebase.

There is one very notable breaking change - previously, when converting Google Drive API responses into Clojure maps, we would suffix the map key with a `?` if the value was literal `true`, but not for any other value (not even `false`).  We will no longer be doing this.

For example, previously, we would convert `{"canInvite" true}` to `{:can-invite? true}`.  After this change, it will instead be transformed to `{:can-invite true}` (note the lack of a question mark).  Keys for other values will remain unchanged, as before (e.g. `{"canInvite" false}` still becomes `{:can-invite false}`

Many helper functions were renamed, and a lot of the file functions were changed and consolidated to push many "optional" config options into a separate, optional map argument rather than taking them as unnamed parameters.  This ultimately should make the simple-case calls easier, while making code performing more advanced customizations easier to read.

If your code interacts with the `google-drive` namespace, you should carefully scrutinize each call and update it to be correct given these API changes.
